### PR TITLE
feat: integrate OIDC login and enhance layout 

### DIFF
--- a/web-gala/src/hooks/useLoginLink.ts
+++ b/web-gala/src/hooks/useLoginLink.ts
@@ -3,7 +3,7 @@ import { useHref } from "react-router-dom";
 
 export default function useLoginLink() {
   const homePathname = useHref("");
-  const loginURL = new URL("/auth/login", config.BASE_URL);
+  const loginURL = new URL("/api/nei/v1/auth/oidc/login", config.BASE_URL);
   const redirectUrl = new URL(homePathname, config.BASE_URL);
 
   loginURL.searchParams.set("redirect_to", redirectUrl.toString());

--- a/web-gala/src/router/routes.tsx
+++ b/web-gala/src/router/routes.tsx
@@ -6,30 +6,28 @@ import ErrorBoundary from "@/pages/ErrorBoundary";
 
 import { useUserStore, UserState } from "@/stores/useUserStore";
 
+const ADMIN_SCOPES = new Set(["admin", "manager-jantar-gala"]);
+
 function ProtectedRoute({
   children,
-  loggedIn = true,
-  redirect = "/auth/login",
+  adminOnly = false,
 }: Readonly<{
   children: React.ReactNode;
-  loggedIn?: boolean;
-  redirect?: string;
+  adminOnly?: boolean;
 }>) {
   const { sessionLoading, token, scopes } = useUserStore(
     (state: UserState) => state,
   );
 
   if (sessionLoading) return null;
-  console.log(scopes);
-  if (!!token === loggedIn) {
-    // Optional: Check for specific scopes if needed
-    if (loggedIn && scopes && !scopes.includes("admin")) {
-      return <Navigate to="/" />;
-    }
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <>{children}</>;
+
+  if (!token) return <Navigate to="/" />;
+
+  if (adminOnly && !scopes?.some((s) => ADMIN_SCOPES.has(s))) {
+    return <Navigate to="/" />;
   }
-  return <Navigate to={redirect} />;
+
+  return <>{children}</>;
 }
 
 const routes = [
@@ -80,7 +78,7 @@ const routes = [
           const { default: Admin } = await import("@/pages/Admin");
           return {
             Component: () => (
-              <ProtectedRoute>
+              <ProtectedRoute adminOnly>
                 <Admin />
               </ProtectedRoute>
             ),

--- a/web-gala/src/services/NEIService.ts
+++ b/web-gala/src/services/NEIService.ts
@@ -8,6 +8,10 @@ const NEIService = {
     const response: NEIUser = await client.get(`/user/${id}`);
     return response;
   },
+
+  logout: async (): Promise<{ end_session_url: string | null }> => {
+    return client.post("/auth/logout");
+  },
 };
 
 export default NEIService;


### PR DESCRIPTION
This pull request updates authentication and authorization logic to support OIDC login, adds a logout API call, and enforces admin-only access for the admin route. The main changes are grouped below:

**Authentication and Authorization Updates:**

* Changed the login URL in `useLoginLink` to use the OIDC endpoint `/api/nei/v1/auth/oidc/login` instead of the old `/auth/login` path.
* Refactored `ProtectedRoute` in `routes.tsx` to enforce admin-only access using a new `adminOnly` prop and a set of allowed admin scopes. The logic now redirects non-admin users away from admin routes.
* Updated the admin route definition to require `adminOnly` access, ensuring only users with the correct scopes can access the admin page.

**API Integration:**

* Added a `logout` method to `NEIService` to support logging out via the `/auth/logout` endpoint.