### PR TITLE
refactor: remove redundant check for already voted option

### DIFF
--- a/api-gala/app/api/vote/_utils.py
+++ b/api-gala/app/api/vote/_utils.py
@@ -24,10 +24,6 @@ def anonymize_category(category: VoteCategory, auth: AuthData) -> VoteListing:
             already_voted = vote.option
 
     already_nominated = any(auth.sub in n.votes for n in category.nominations)
-        if vote.uid == auth.sub:
-            already_voted = vote.option
-        if vote.uid == auth.sub:
-            already_voted = vote.option
 
     return VoteListing(
         _id=category.id,


### PR DESCRIPTION
This pull request makes a minor cleanup to the `anonymize_category` function in `api-gala/app/api/vote/_utils.py`. The change removes two redundant checks for whether the current user has already voted, simplifying the code without affecting functionality.

* Removed duplicate checks for `vote.uid == auth.sub` and assignment to `already_voted` in `anonymize_category`, reducing unnecessary code.