### PR TITLE
fix(registration): count companion seats in bus capacity enforcement

### DIFF
--- a/api-gala/app/api/registration.py
+++ b/api-gala/app/api/registration.py
@@ -65,9 +65,7 @@ async def get_registration_capacity(
 
     bus_remaining: Optional[int] = None
     if limits.maxBusSeats is not None:
-        taken = await User.get_collection(db).count_documents(
-            {"bus_option": {"$ne": "NONE"}}
-        )
+        taken = await RegistrationService.count_bus_seats_taken(db)
         bus_remaining = max(0, limits.maxBusSeats - taken)
 
     return RegistrationCapacity(remaining=remaining, total=limits.maxRegistrations, bus_remaining=bus_remaining)
@@ -153,10 +151,9 @@ async def update_registration_step(
                 detail="As inscrições estão encerradas.",
             )
         if user.bus_option.value != "NONE" and limits.maxBusSeats is not None:
-            taken = await User.get_collection(db).count_documents(
-                {"bus_option": {"$ne": "NONE"}}
-            )
-            if taken > limits.maxBusSeats:
+            taken = await RegistrationService.count_bus_seats_taken(db, exclude_user_id=auth.sub)
+            my_seats = 1 + len(user.companions)
+            if taken + my_seats > limits.maxBusSeats:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail="Não há mais lugares disponíveis no autocarro. Volta ao passo 3 e escolhe deslocação própria.",
@@ -164,13 +161,13 @@ async def update_registration_step(
 
     if step == 3:
         new_bus = data.get("bus_option", "NONE")
-        if new_bus not in ("NONE", None) and user.bus_option.value == "NONE":
+        if new_bus not in ("NONE", None):
             limits = await fetch_limits(db)
             if limits.maxBusSeats is not None:
-                taken = await User.get_collection(db).count_documents(
-                    {"bus_option": {"$ne": "NONE"}}
-                )
-                if taken >= limits.maxBusSeats:
+                taken = await RegistrationService.count_bus_seats_taken(db, exclude_user_id=auth.sub)
+                new_companions = data.get("companions") or []
+                seats_needed = 1 + len(new_companions)
+                if taken + seats_needed > limits.maxBusSeats:
                     raise HTTPException(
                         status_code=status.HTTP_409_CONFLICT,
                         detail="Não há mais lugares disponíveis no autocarro.",

--- a/api-gala/app/services/registration.py
+++ b/api-gala/app/services/registration.py
@@ -83,6 +83,24 @@ class RegistrationService:
         return row["registrations"] + row["companions"]
 
     @staticmethod
+    async def count_bus_seats_taken(db: DBType, exclude_user_id: Optional[int] = None) -> int:
+        """Counts bus seats occupied by all users with a non-NONE bus option.
+        Each user takes 1 seat plus 1 per companion.
+        Pass exclude_user_id to exclude a specific user (e.g. before re-saving their own entry).
+        """
+        match: Dict[str, Any] = {"bus_option": {"$ne": "NONE"}}
+        if exclude_user_id is not None:
+            match["_id"] = {"$ne": exclude_user_id}
+        result = await User.get_collection(db).aggregate([
+            {"$match": match},
+            {"$group": {
+                "_id": None,
+                "total": {"$sum": {"$add": [1, {"$size": {"$ifNull": ["$companions", []]}}]}},
+            }},
+        ]).to_list(1)
+        return result[0]["total"] if result else 0
+
+    @staticmethod
     async def get_user_registration(db: DBType, user_id: int) -> Optional[User]:
         collection = User.get_collection(db)
         user_dict = await collection.find_one({"_id": user_id})


### PR DESCRIPTION
Add RegistrationService.count_bus_seats_taken() which sums 1 + len(companions) per user with a non-NONE bus option, matching how count_registered_attendees works for total capacity.

Use it in all three enforcement points:
- /capacity endpoint (bus_remaining shown in frontend)
- step 3 guard: exclude the current user's old state, count new companions
- step 6 guard: exclude the current user, add their companion count