### PR TITLE
fix(registration): exclude companion-via-email records from payment d…

### DIFF
--- a/api-gala/app/services/registration.py
+++ b/api-gala/app/services/registration.py
@@ -163,6 +163,7 @@ class RegistrationService:
             await user_coll.update_many(
                 {
                     "is_registered": True,
+                    "is_companion_of": None,
                     "registration_active": {"$ne": False},
                     "has_payed": {"$ne": True},
                     "phased_payment": {"$ne": True},
@@ -181,6 +182,7 @@ class RegistrationService:
             await user_coll.update_many(
                 {
                     "is_registered": True,
+                    "is_companion_of": None,
                     "registration_active": {"$ne": False},
                     "has_payed": {"$ne": True},
                     "phased_payment": True,
@@ -197,6 +199,7 @@ class RegistrationService:
             await user_coll.update_many(
                 {
                     "is_registered": True,
+                    "is_companion_of": None,
                     "registration_active": {"$ne": False},
                     "has_payed": {"$ne": True},
                     "phased_payment": True,

--- a/api-gala/tests/test_registration_service.py
+++ b/api-gala/tests/test_registration_service.py
@@ -420,6 +420,7 @@ async def test_apply_payment_deadline_policy_expired_deadline():
 
         assert full_payment_filter == {
             "is_registered": True,
+            "is_companion_of": None,
             "registration_active": {"$ne": False},
             "has_payed": {"$ne": True},
             "phased_payment": {"$ne": True},
@@ -430,6 +431,7 @@ async def test_apply_payment_deadline_policy_expired_deadline():
         }
         assert phase1_filter == {
             "is_registered": True,
+            "is_companion_of": None,
             "registration_active": {"$ne": False},
             "has_payed": {"$ne": True},
             "phased_payment": True,
@@ -440,6 +442,7 @@ async def test_apply_payment_deadline_policy_expired_deadline():
         }
         assert phase2_filter == {
             "is_registered": True,
+            "is_companion_of": None,
             "registration_active": {"$ne": False},
             "has_payed": {"$ne": True},
             "phased_payment": True,
@@ -541,6 +544,7 @@ async def test_apply_payment_deadline_policy_only_expires_phase1_when_only_phase
         filter_doc, update_doc = user_coll.update_many.call_args.args
         assert filter_doc == {
             "is_registered": True,
+            "is_companion_of": None,
             "registration_active": {"$ne": False},
             "has_payed": {"$ne": True},
             "phased_payment": True,


### PR DESCRIPTION
…eadline policy

Companions never pay independently — their registration is managed by the host. The apply_payment_deadline_policy was matching is_companion_of records (is_registered=True, has_payed=False, no proof) and marking them registration_active=False, payment_expired=True, which blocked them from voting via require_registered_user.

Add is_companion_of: None to all three update_many filters.